### PR TITLE
Fix rawrtc_message_buffer_clear to clear more than 1 message

### DIFF
--- a/src/message_buffer/buffer.c
+++ b/src/message_buffer/buffer.c
@@ -76,6 +76,7 @@ enum rawrtc_code rawrtc_message_buffer_clear(
     le = list_head(message_buffer);
     while (le != NULL) {
         struct buffered_message* const buffered_message = le->data;
+        struct le* next = le->next;
 
         // Handle message
         unlink = message_handler(buffered_message->buffer, buffered_message->context, arg);
@@ -84,7 +85,7 @@ enum rawrtc_code rawrtc_message_buffer_clear(
         }
 
         // Get next message
-        le = le->next;
+        le = next;
 
         // Remove message
         if (unlink) {


### PR DESCRIPTION
list_unlink sets le->next to NULL.  The end result is that the while
loop would terminate after one iteration because le == NULL.

rawrtc_message_buffer_clear looks to be designed to clear out as many
messages as possible until message_handler returns false.  At that
point, it reports that it stopped iterating.

Instead of terminating, actually update le to the next element
correctly.